### PR TITLE
feat(function-timer): add FunctionTimer module

### DIFF
--- a/lib/metrix.ex
+++ b/lib/metrix.ex
@@ -1,18 +1,25 @@
 defmodule Metrix do
   @moduledoc """
-  Documentation for Metrix.
+  Metrix is a library for collecting StatsD metrics. It is built on top of [`statix`](https://github.com/lexmag/statix). By using Statix, the following functions
+  are injected into this module:
+
+  * decrement/1,2,3
+  * gauge/2,3
+  * histogram/2,3
+  * increment/1,2,3
+  * measure/2,3
+  * set/2,3
+  * timing/2,3
   """
+
+  use Statix
 
   @doc """
-  Hello world.
-
-  ## Examples
-
-      iex> Metrix.hello()
-      :world
-
+  The #{__MODULE__}.start/0 method is used to create a socket connection with the
+  configured StatsD server.
   """
-  def hello do
-    :world
+  @spec start() :: :ok
+  def start do
+    :ok = __MODULE__.connect()
   end
 end

--- a/lib/metrix/function_timer.ex
+++ b/lib/metrix/function_timer.ex
@@ -1,0 +1,151 @@
+defmodule Metrix.FunctionTimer do
+  @moduledoc """
+  The #{__MODULE__} module provides a way to easily time functions and send metrics
+  to a StatsD server, with out having to manually time each function.
+  """
+
+  defmacro __using__(opts) do
+    quote do
+      import Metrix.FunctionTimer
+      @use_histogram Keyword.get(unquote(opts), :use_histogram)
+      @default_metric_options []
+    end
+  end
+
+  defmacro deftimed(head, body \\ nil) do
+    {function_name, args_ast} = Macro.decompose_call(head)
+    arg_length = length(args_ast)
+    function_id = "#{function_name}_#{arg_length}"
+
+    quote do
+      @metrix_metric_name metric_name(__MODULE__, unquote(function_id))
+      @metrix_metric_options metric_options(__MODULE__, unquote(function_id))
+      @timing_function timing_function(__MODULE__)
+      def unquote(head) do
+        {time, value} = :timer.tc(fn -> unquote(body[:do]) end)
+        milliseconds = time / 1_000
+
+        Kernel.apply(Metrix, @timing_function, [
+          @metrix_metric_name,
+          milliseconds,
+          @metrix_metric_options
+        ])
+
+        value
+      end
+    end
+  end
+
+  @doc ~S"""
+  The metric_name/2 function is responsible for fetching the metric
+  name for the function being timed. A custom metric name can be set by setting a
+  `@metric_name` module attribute above the function, otherwise, a default metric
+  name is used.
+
+  If the default metric name is used, it is set as a module attribute, with the
+  name `"#{function_id}_metric_name"`.
+
+  If a custom metric name is set with `@metric_name`, the name is moved to the
+  `"#{function_id}_metric_name"` module attribute, and `@metric_name` is set to
+  `nil` so that it can be overwritten further down in the file.
+  """
+  def metric_name(module, function_id) do
+    if custom_metric_name = Module.get_attribute(module, :metric_name) do
+      move_metric_name(module, function_id, custom_metric_name)
+    else
+      get_metric_name(module, function_id)
+    end
+  end
+
+  @doc ~S"""
+  The metric_options/2 function is responsible for fetching the metric
+  options for the function being timed. Custom metric options can be set by setting a
+  `@metric_options` module attribute above the function, otherwise, default metric
+  options are used.
+
+  If the default metric options are used, they are set as a module attribute, with the
+  name `"#{function_id}_metric_options"`.
+
+  If custom metric options are set with `@metric_options`, the options are moved to the
+  `"#{function_id}_metric_options"` module attribute, and `@metric_options` is set to
+  `nil` so that it can be overwritten further down in the file.
+  """
+  def metric_options(module, function_id) do
+    if custom_metric_options = Module.get_attribute(module, :metric_options) do
+      move_metric_options(module, function_id, custom_metric_options)
+    else
+      get_metric_options(module, function_id)
+    end
+  end
+
+  @doc ~S"""
+  The timing_function/1 function is used to determine whether to
+  make a call to Metrix.histogram/3 or Metrix.timing/3. By default, Metrix.timing/3
+  will be called, but this can be overriden with:
+
+  defmodule UseHistogram do
+    use Metrix.FunctionTimer, use_histogram: true
+  end
+  """
+  def timing_function(module) do
+    if Module.get_attribute(module, :use_histogram), do: :histogram, else: :timing
+  end
+
+  defp move_metric_name(module, function_id, metric_name) do
+    metric_name_atom = metric_name_atom(function_id)
+
+    Module.put_attribute(module, metric_name_atom, metric_name)
+    Module.put_attribute(module, :metric_name, nil)
+
+    metric_name
+  end
+
+  defp get_metric_name(module, function_id) do
+    metric_name_atom = metric_name_atom(function_id)
+
+    if function_metric = Module.get_attribute(module, metric_name_atom) do
+      function_metric
+    else
+      default = default_metric_name(module, function_id)
+      Module.put_attribute(module, metric_name_atom, default)
+      default
+    end
+  end
+
+  defp metric_name_atom(function_id) do
+    String.to_atom("#{function_id}_metric_name")
+  end
+
+  defp default_metric_name(module, function_id) do
+    String.downcase("function_call.#{module}.#{function_id}")
+  end
+
+  defp move_metric_options(module, function_id, options) do
+    metric_options_atom = metric_options_atom(function_id)
+
+    Module.put_attribute(module, metric_options_atom, options)
+    Module.put_attribute(module, :metric_options, nil)
+
+    options
+  end
+
+  defp get_metric_options(module, function_id) do
+    metric_options_atom = metric_options_atom(function_id)
+
+    if function_options = Module.get_attribute(module, metric_options_atom) do
+      function_options
+    else
+      defaults = default_metric_options(module)
+      Module.put_attribute(module, metric_options_atom, defaults)
+      defaults
+    end
+  end
+
+  defp metric_options_atom(function_id) do
+    String.to_atom("#{function_id}_metric_options")
+  end
+
+  defp default_metric_options(module) do
+    Module.get_attribute(module, :default_metric_options)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -38,10 +38,11 @@ defmodule Metrix.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:ex_doc, "~> 0.19.0", only: :dev, runtime: false},
       {:credo, "~> 1.0.0", only: [:dev, :test], runtime: false},
+      {:ex_doc, "~> 0.19.0", only: :dev, runtime: false},
       {:excoveralls, "~> 0.11.1", only: :test},
       {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false},
+      {:mimic, "~> 0.3", only: :test},
       {:statix, "~> 1.1.0"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -13,6 +13,7 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm"},
+  "mimic": {:hex, :mimic, "0.3.0", "584dfd5ac2ce3347f56b0de3b7906554e2f6020007efed37e721b968f27ebbc0", [:mix], [], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "parse_trans": {:hex, :parse_trans, "3.3.0", "09765507a3c7590a784615cfd421d101aec25098d50b89d7aa1d66646bc571c1", [:rebar3], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.4", "f0eafff810d2041e93f915ef59899c923f4568f4585904d010387ed74988e77b", [:make, :mix, :rebar3], [], "hexpm"},

--- a/test/metrix/function_timer_test.exs
+++ b/test/metrix/function_timer_test.exs
@@ -1,0 +1,165 @@
+defmodule Metrix.FunctionTimerTest do
+  use ExUnit.Case, async: false
+  import Mimic
+
+  @default_prefix "function_call.elixir.metrix.functiontimertest.timedmodule"
+
+  defmodule MetricsAgent do
+    use Agent
+
+    def start_link() do
+      Agent.start_link(fn -> nil end, name: __MODULE__)
+    end
+
+    def get() do
+      Agent.get(__MODULE__, fn state -> state end)
+    end
+
+    def set(values) do
+      Agent.update(__MODULE__, fn _ -> values end)
+    end
+  end
+
+  defmodule TimedModule do
+    use Metrix.FunctionTimer
+
+    deftimed(default, do: :default)
+
+    @metric_name "custom_metric"
+    deftimed(custom_metric_name, do: :custom_metric_name)
+
+    deftimed(no_custom_metric_name, do: :no_custom_metric_name)
+
+    @metric_name "multiple"
+    deftimed(multiple(:option_1), do: :multiple_1)
+    deftimed(multiple(:option_2), do: :multiple_2)
+
+    @metric_name "multiple_default"
+    deftimed(multiple(_), do: :multiple_default)
+
+    @metric_options [tags: [:custom_options_tag]]
+    deftimed(custom_metric_options, do: :custom_metric_options)
+
+    deftimed(no_custom_metric_options, do: :no_custom_metric_options)
+
+    @metric_options [tags: [:multiple_options_tag]]
+    deftimed(multiple_options(:option_1), do: :multiple_options_1)
+    deftimed(multiple_options(:option_2), do: :multiple_options_2)
+
+    @metric_options [tags: [:multiple_options_default_tag]]
+    deftimed(multiple_options(_), do: :multiple_options_default)
+  end
+
+  describe "deftimed/2" do
+    setup :set_mimic_global
+
+    setup _context do
+      MetricsAgent.start_link()
+
+      stub(Metrix, :timing, fn name, value, options ->
+        MetricsAgent.set({name, value, options})
+      end)
+
+      stub(Metrix, :histogram, fn name, value, options ->
+        MetricsAgent.set({name, value, options})
+      end)
+
+      :ok
+    end
+
+    test "default metric name and options" do
+      result = TimedModule.default()
+      {metric_name, time, []} = MetricsAgent.get()
+
+      assert result == :default
+      assert metric_name == "#{@default_prefix}.default_0"
+      assert is_float(time)
+    end
+
+    test "custom metric name" do
+      result = TimedModule.custom_metric_name()
+      {metric_name, time, []} = MetricsAgent.get()
+
+      assert result == :custom_metric_name
+      assert metric_name == "custom_metric"
+      assert is_float(time)
+    end
+
+    test "custom metric name does not apply to next function in file" do
+      result = TimedModule.no_custom_metric_name()
+      {metric_name, time, []} = MetricsAgent.get()
+
+      assert result == :no_custom_metric_name
+      assert metric_name == "#{@default_prefix}.no_custom_metric_name_0"
+      assert is_float(time)
+    end
+
+    test "custom metric name applies to multiple function headers" do
+      result1 = TimedModule.multiple(:option_1)
+      {metric_name1, time1, []} = MetricsAgent.get()
+
+      result2 = TimedModule.multiple(:option_2)
+      {metric_name2, time2, []} = MetricsAgent.get()
+
+      assert result1 == :multiple_1
+      assert metric_name1 == "multiple"
+      assert is_float(time1)
+
+      assert result2 == :multiple_2
+      assert metric_name2 == "multiple"
+      assert is_float(time2)
+    end
+
+    test "custom metric name can be written on a per-function-header level" do
+      result = TimedModule.multiple(:other_argument)
+      {metric_name, time, []} = MetricsAgent.get()
+
+      assert result == :multiple_default
+      assert metric_name == "multiple_default"
+      assert is_float(time)
+    end
+
+    test "supports custom metric options" do
+      result = TimedModule.custom_metric_options()
+      {_metric_name, time, options} = MetricsAgent.get()
+
+      assert result == :custom_metric_options
+      assert is_float(time)
+      assert options == [tags: [:custom_options_tag]]
+    end
+
+    test "custom metric options do not apply to next function in file" do
+      result = TimedModule.no_custom_metric_options()
+      {_metric_name, time, options} = MetricsAgent.get()
+
+      assert result == :no_custom_metric_options
+      assert is_float(time)
+      assert options == []
+    end
+
+    test "custom metric options apply to multiple function headers" do
+      result1 = TimedModule.multiple_options(:option_1)
+      {_metric_name, time1, options1} = MetricsAgent.get()
+
+      result2 = TimedModule.multiple_options(:option_2)
+      {_metric_name, time2, options2} = MetricsAgent.get()
+
+      assert result1 == :multiple_options_1
+      assert is_float(time1)
+      assert options1 == [tags: [:multiple_options_tag]]
+
+      assert result2 == :multiple_options_2
+      assert is_float(time2)
+      assert options2 == [tags: [:multiple_options_tag]]
+    end
+
+    test "custom metric options can be written on a per-function-header level" do
+      result = TimedModule.multiple_options(:other_argument)
+      {_metric_name, time, options} = MetricsAgent.get()
+
+      assert result == :multiple_options_default
+      assert is_float(time)
+      assert options == [tags: [:multiple_options_default_tag]]
+    end
+  end
+end

--- a/test/metrix_test.exs
+++ b/test/metrix_test.exs
@@ -1,8 +1,9 @@
 defmodule MetrixTest do
-  use ExUnit.Case
-  doctest Metrix
+  use ExUnit.Case, async: true
 
-  test "greets the world" do
-    assert Metrix.hello() == :world
+  describe "start/0" do
+    test "starts Metrix by opening a UDP socket" do
+      assert Metrix.start() == :ok
+    end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
+Mimic.copy(Metrix)
 ExUnit.start()


### PR DESCRIPTION
**Changes**:

- [x] Adds `Metrix.FunctionTimer` module, which can be used to easily gather function timing metrics.
- [x] Adds the `Metrix.start()` method, which starts Statix.
- [x] Adds function docs and module docs.