### PR TITLE
fix(plug): remove trailing . from metric name

### DIFF
--- a/lib/ex_metrics/plug.ex
+++ b/lib/ex_metrics/plug.ex
@@ -39,6 +39,8 @@ defmodule ExMetrics.Plug do
   defp metric_name_from_request_path(request_path) do
     request_path
     |> String.replace("/", ".")
+    |> String.replace(~r/\.+/, ".")
+    |> String.trim_trailing(".")
     |> String.replace(":", "")
   end
 end

--- a/test/ex_metrics/plug_test.exs
+++ b/test/ex_metrics/plug_test.exs
@@ -87,5 +87,21 @@ defmodule ExMetrics.PlugTest do
       assert name == "response_time.root"
       assert is_float(time)
     end
+
+    test "strips multiple consecutive periods" do
+      conn = conn(:get, "/v2/users/?id=1234")
+
+      result_conn =
+        conn
+        |> ExMetrics.Plug.call([])
+        |> Plug.Conn.send_resp(200, "")
+
+      {:timing, name, time} = MetricsAgent.get()
+
+      assert result_conn.status == 200
+      assert result_conn.state == :sent
+      assert name == "response_time.v2.users"
+      assert is_float(time)
+    end
   end
 end


### PR DESCRIPTION
### Changes

- [x] Replaces consecutive `.`s with a single `.`.
- [x] Removes a trailing `.` if present.